### PR TITLE
Set claims appropriately on the id_token

### DIFF
--- a/samples/PasswordFlow/AuthorizationServer/Controllers/AuthorizationController.cs
+++ b/samples/PasswordFlow/AuthorizationServer/Controllers/AuthorizationController.cs
@@ -169,7 +169,7 @@ namespace AuthorizationServer.Controllers
                     destinations.Add(OpenIdConnectConstants.Destinations.IdentityToken);
                 }
 
-                claim.SetDestinations(OpenIdConnectConstants.Destinations.AccessToken);
+                claim.SetDestinations(destinations);
             }
 
             return ticket;


### PR DESCRIPTION
The old version of this code would have the effect of never setting any of the name, email or role claims on the id_token. This change fixes that, and  makes this controller consistent with similar lines in the Refresh Flow, Implicit Flow and Authorization Code Flow example authorization controllers:

https://github.com/openiddict/openiddict-samples/blob/master/samples/RefreshFlow/AuthorizationServer/Controllers/AuthorizationController.cs#L216
https://github.com/openiddict/openiddict-samples/blob/master/samples/ImplicitFlow/AuthorizationServer/Controllers/AuthorizationController.cs#L147
https://github.com/openiddict/openiddict-samples/blob/master/samples/CodeFlow/AuthorizationServer/Controllers/AuthorizationController.cc#L243