### PR TITLE
Use content root to resolve views

### DIFF
--- a/samples/CodeFlow/AuthorizationServer/Program.cs
+++ b/samples/CodeFlow/AuthorizationServer/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace AuthorizationServer
 {
@@ -17,6 +18,7 @@ namespace AuthorizationServer
                 .ConfigureLogging(options => options.AddConsole())
                 .ConfigureLogging(options => options.AddDebug())
                 .UseConfiguration(configuration)
+                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseKestrel()
                 .UseStartup<Startup>()

--- a/samples/CodeFlow/ClientApp/Program.cs
+++ b/samples/CodeFlow/ClientApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace ClientApp
 {
@@ -17,6 +18,7 @@ namespace ClientApp
                 .ConfigureLogging(options => options.AddConsole())
                 .ConfigureLogging(options => options.AddDebug())
                 .UseConfiguration(configuration)
+                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseKestrel()
                 .UseStartup<Startup>()

--- a/samples/ImplicitFlow/AuthorizationServer/Program.cs
+++ b/samples/ImplicitFlow/AuthorizationServer/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.IO;
 
 namespace AuthorizationServer
 {
@@ -17,6 +18,7 @@ namespace AuthorizationServer
                 .ConfigureLogging(options => options.AddConsole())
                 .ConfigureLogging(options => options.AddDebug(LogLevel.Trace))
                 .UseConfiguration(configuration)
+                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseKestrel()
                 .UseStartup<Startup>()


### PR DESCRIPTION
We were otherwise receiving this error: 

> System.InvalidOperationException: The view 'Index' was not found. The following locations were searched...

The following ASP.NET Core MVC project need this fix.

* [x] ClientCredentialsFlow. Not necessary. There is no Web UI. 
* [x] CodeFlow. 
* [x] ImplicitFlow           
* [x] PasswordFlow. Not necessary. There is no Web UI. 
* [x] RefreshFlow. Not necessary. Angular handles the Web UI. 