### PR TITLE
explicitly use rc2 since rc3 has breaking changes

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
     <AspNetContribOpenIdExtensionsVersion>2.0.0-*</AspNetContribOpenIdExtensionsVersion>
     <JsonNetVersion>10.0.2</JsonNetVersion>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
-    <OpenIddictVersion>2.0.0-*</OpenIddictVersion>
+    <OpenIddictVersion>2.0.0-rc2-final</OpenIddictVersion>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
on a new machine, rc3 is restored and causes compiler errors