### PR TITLE
Use same audience

### DIFF
--- a/samples/ClientCredentialsFlow/AuthorizationServer/Controllers/AuthorizationController.cs
+++ b/samples/ClientCredentialsFlow/AuthorizationServer/Controllers/AuthorizationController.cs
@@ -85,7 +85,7 @@ namespace AuthorizationServer.Controllers
                 new AuthenticationProperties(),
                 OpenIddictServerDefaults.AuthenticationScheme);
 
-            ticket.SetResources("resource_server");
+            ticket.SetResources("resource-server");
 
             return ticket;
         }

--- a/samples/ClientCredentialsFlow/AuthorizationServer/Startup.cs
+++ b/samples/ClientCredentialsFlow/AuthorizationServer/Startup.cs
@@ -85,7 +85,7 @@ namespace AuthorizationServer
             //     .AddJwtBearer(options =>
             //     {
             //         options.Authority = "http://localhost:52698/";
-            //         options.Audience = "resource_server";
+            //         options.Audience = "resource-server";
             //         options.RequireHttpsMetadata = false;
             //         options.TokenValidationParameters = new TokenValidationParameters
             //         {
@@ -102,8 +102,8 @@ namespace AuthorizationServer
             //     .AddOAuthIntrospection(options =>
             //     {
             //         options.Authority = new Uri("http://localhost:52698/");
-            //         options.Audiences.Add("resource_server");
-            //         options.ClientId = "resource_server";
+            //         options.Audiences.Add("resource-server");
+            //         options.ClientId = "resource-server";
             //         options.ClientSecret = "875sqd4s5d748z78z7ds1ff8zz8814ff88ed8ea4z4zzd";
             //         options.RequireHttpsMetadata = false;
             //     });

--- a/samples/CodeFlow/AuthorizationServer/Controllers/AuthorizationController.cs
+++ b/samples/CodeFlow/AuthorizationServer/Controllers/AuthorizationController.cs
@@ -209,7 +209,7 @@ namespace AuthorizationServer.Controllers
                 }.Intersect(request.GetScopes()));
             }
 
-            ticket.SetResources("resource_server");
+            ticket.SetResources("resource-server");
 
             // Note: by default, claims are NOT automatically included in the access and identity tokens.
             // To allow OpenIddict to serialize them, you must attach them a destination, that specifies

--- a/samples/CodeFlow/AuthorizationServer/Startup.cs
+++ b/samples/CodeFlow/AuthorizationServer/Startup.cs
@@ -132,7 +132,7 @@ namespace AuthorizationServer
             //     .AddJwtBearer(options =>
             //     {
             //         options.Authority = "http://localhost:54540/";
-            //         options.Audience = "resource_server";
+            //         options.Audience = "resource-server";
             //         options.RequireHttpsMetadata = false;
             //         options.TokenValidationParameters = new TokenValidationParameters
             //         {
@@ -149,8 +149,8 @@ namespace AuthorizationServer
             //     .AddOAuthIntrospection(options =>
             //     {
             //         options.Authority = new Uri("http://localhost:54540/");
-            //         options.Audiences.Add("resource_server");
-            //         options.ClientId = "resource_server";
+            //         options.Audiences.Add("resource-server");
+            //         options.ClientId = "resource-server";
             //         options.ClientSecret = "875sqd4s5d748z78z7ds1ff8zz8814ff88ed8ea4z4zzd";
             //         options.RequireHttpsMetadata = false;
             //     });

--- a/samples/PasswordFlow/AuthorizationServer/Startup.cs
+++ b/samples/PasswordFlow/AuthorizationServer/Startup.cs
@@ -101,7 +101,7 @@ namespace AuthorizationServer
             //     .AddJwtBearer(options =>
             //     {
             //         options.Authority = "http://localhost:58795/";
-            //         options.Audience = "resource_server";
+            //         options.Audience = "resource-server";
             //         options.RequireHttpsMetadata = false;
             //         options.TokenValidationParameters = new TokenValidationParameters
             //         {
@@ -118,8 +118,8 @@ namespace AuthorizationServer
             //     .AddOAuthIntrospection(options =>
             //     {
             //         options.Authority = new Uri("http://localhost:58795/");
-            //         options.Audiences.Add("resource_server");
-            //         options.ClientId = "resource_server";
+            //         options.Audiences.Add("resource-server");
+            //         options.ClientId = "resource-server";
             //         options.ClientSecret = "875sqd4s5d748z78z7ds1ff8zz8814ff88ed8ea4z4zzd";
             //         options.RequireHttpsMetadata = false;
             //     });

--- a/samples/RefreshFlow/AuthorizationServer/Controllers/AuthorizationController.cs
+++ b/samples/RefreshFlow/AuthorizationServer/Controllers/AuthorizationController.cs
@@ -142,7 +142,7 @@ namespace AuthorizationServer.Controllers
                 }.Intersect(request.GetScopes()));
             }
 
-            ticket.SetResources("resource_server");
+            ticket.SetResources("resource-server");
 
             // Note: by default, claims are NOT automatically included in the access and identity tokens.
             // To allow OpenIddict to serialize them, you must attach them a destination, that specifies

--- a/samples/RefreshFlow/AuthorizationServer/Startup.cs
+++ b/samples/RefreshFlow/AuthorizationServer/Startup.cs
@@ -102,7 +102,7 @@ namespace AuthorizationServer
             //     .AddJwtBearer(options =>
             //     {
             //         options.Authority = "http://localhost:54895/";
-            //         options.Audience = "resource_server";
+            //         options.Audience = "resource-server";
             //         options.RequireHttpsMetadata = false;
             //         options.TokenValidationParameters = new TokenValidationParameters
             //         {
@@ -119,8 +119,8 @@ namespace AuthorizationServer
             //     .AddOAuthIntrospection(options =>
             //     {
             //         options.Authority = new Uri("http://localhost:54895/");
-            //         options.Audiences.Add("resource_server");
-            //         options.ClientId = "resource_server";
+            //         options.Audiences.Add("resource-server");
+            //         options.ClientId = "resource-server";
             //         options.ClientSecret = "875sqd4s5d748z78z7ds1ff8zz8814ff88ed8ea4z4zzd";
             //         options.RequireHttpsMetadata = false;
             //     });


### PR DESCRIPTION
To avoid `Bearer error="invalid_token", error_description="The audience is invalid"` exception.