### PR TITLE
Kalarba server without autofac

### DIFF
--- a/OpenIddict.Samples.sln
+++ b/OpenIddict.Samples.sln
@@ -86,7 +86,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Weytta", "Weytta", "{374481
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Weytta.Client", "samples\Weytta\Weytta.Client\Weytta.Client.csproj", "{20C5B39E-CEBA-4CCD-979A-5499B4030043}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Weytta.Server", "samples\Weytta\Weytta.Server\Weytta.Server.csproj", "{02D5D1C5-675D-482D-9F74-F06FC522D2CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Weytta.Server", "samples\Weytta\Weytta.Server\Weytta.Server.csproj", "{02D5D1C5-675D-482D-9F74-F06FC522D2CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KalarbaMSDI.Server", "samples\Kalarba\KalarbaMSDI.Server\KalarbaMSDI.Server.csproj", "{193B7187-D1E0-45B0-A659-DF38702CF3ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -170,6 +172,10 @@ Global
 		{02D5D1C5-675D-482D-9F74-F06FC522D2CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02D5D1C5-675D-482D-9F74-F06FC522D2CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02D5D1C5-675D-482D-9F74-F06FC522D2CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{193B7187-D1E0-45B0-A659-DF38702CF3ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{193B7187-D1E0-45B0-A659-DF38702CF3ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{193B7187-D1E0-45B0-A659-DF38702CF3ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{193B7187-D1E0-45B0-A659-DF38702CF3ED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -202,6 +208,7 @@ Global
 		{37448199-E002-4FA0-A712-B6DB22DA98EC} = {8B467944-153B-4C90-BAB1-8F1B34C3075A}
 		{20C5B39E-CEBA-4CCD-979A-5499B4030043} = {37448199-E002-4FA0-A712-B6DB22DA98EC}
 		{02D5D1C5-675D-482D-9F74-F06FC522D2CC} = {37448199-E002-4FA0-A712-B6DB22DA98EC}
+		{193B7187-D1E0-45B0-A659-DF38702CF3ED} = {196EEDE4-CF84-44D5-905B-30F341F7617E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F3ECDD26-F40D-4AB4-BC48-8DF143F98FAE}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ASP.NET Core samples demonstrating **how to use [OpenIddict](https://github.com/
   - [Hollastin](samples/Hollastin): resource owner password credentials demo, with a .NET console acting as the client.
   - [Imynusoph](samples/Imynusoph): refresh token grant demo, with an Angular JS application acting as the client.
   - [Kalarba](samples/Kalarba): resource owner password credentials demo using OWIN/Katana, ASP.NET Web API and the OpenIddict degraded mode.
+    - [KalarbaMSDI.Server]: Port of Kalarba server without autofac dependency. Instead it uses Microsoft.Extensions.DependencyInjection
   - [Velusia](samples/Velusia): authorization code flow demo, with an ASP.NET Core application acting as the client.
   - [Weytta](samples/Weytta): authorization code flow with Integrated Windows Authentication support and a .NET console acting as the client.
   - [Zirku](samples/Zirku): implicit flow demo, with an Aurelia JS application acting as the client and two API projects using introspection (Api1) and local validation (Api2).

--- a/samples/Kalarba/KalarbaMSDI.Server/Controllers/ResourceController.cs
+++ b/samples/Kalarba/KalarbaMSDI.Server/Controllers/ResourceController.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+using System.Security.Claims;
+using System.Web.Http;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace Kalarba.Server.Controllers
+{
+    [RoutePrefix("api")]
+    public class ResourceController : ApiController
+    {
+        [Authorize, HttpGet]
+        [Route("message")]
+        public IHttpActionResult GetMessage()
+        {
+            var principal = (ClaimsPrincipal) User;
+            var name = principal.FindFirst(Claims.Name).Value;
+
+            return Content(HttpStatusCode.OK, $"{name} has been successfully authenticated.");
+        }
+    }
+}

--- a/samples/Kalarba/KalarbaMSDI.Server/DefaultDependencyResolver.cs
+++ b/samples/Kalarba/KalarbaMSDI.Server/DefaultDependencyResolver.cs
@@ -1,0 +1,37 @@
+﻿namespace Kalarba.Server
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Web.Http.Dependencies;
+    using Microsoft.Extensions.DependencyInjection;
+    // ...
+
+    public class DefaultDependencyResolver : IDependencyResolver
+    {
+        private readonly IServiceProvider provider;
+
+        public DefaultDependencyResolver(IServiceProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return provider.GetService(serviceType);
+        }
+
+        public IEnumerable<object> GetServices(Type serviceType)
+        {
+            return provider.GetServices(serviceType);
+        }
+
+        public IDependencyScope BeginScope()
+        {
+            return this;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/samples/Kalarba/KalarbaMSDI.Server/KalarbaMSDI.Server.csproj
+++ b/samples/Kalarba/KalarbaMSDI.Server/KalarbaMSDI.Server.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Owin" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Owin.Diagnostics" />
+    <PackageReference Include="Microsoft.Owin.Host.HttpListener" />
+    <PackageReference Include="Microsoft.Owin.Hosting" />
+    <PackageReference Include="OpenIddict.Owin" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Kalarba/KalarbaMSDI.Server/Program.cs
+++ b/samples/Kalarba/KalarbaMSDI.Server/Program.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Microsoft.Owin.Hosting;
+
+namespace Kalarba.Server
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            const string address = "http://localhost:58779/";
+            using (WebApp.Start<Startup>(address))
+            {
+                Console.WriteLine($"Server is running on {address}, press CTRL+C to stop.");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/samples/Kalarba/KalarbaMSDI.Server/Startup.cs
+++ b/samples/Kalarba/KalarbaMSDI.Server/Startup.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Security.Claims;
+using System.Web.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.Owin;
+using OpenIddict.Validation.Owin;
+using Owin;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Kalarba.Server
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            var container = CreateContainer();
+
+            app.Use(async (context, next) =>
+            {
+                var scope = container.CreateScope();
+                // Store the per-request service provider in the OWIN environment.
+                context.Set(typeof(IServiceProvider).FullName, scope.ServiceProvider);
+                try
+                {
+                    // Invoke the rest of the pipeline.
+                    await next();
+                }
+                finally
+                {
+                    // Remove the scoped service provider from the OWIN environment.
+                    context.Set<IServiceProvider>(typeof(IServiceProvider).FullName, null);
+                    // Dispose of the scoped service provider.
+                    if (scope is IAsyncDisposable disposable)
+                    {
+                        await disposable.DisposeAsync();
+                    }
+                    else
+                    {
+                        scope.Dispose();
+                    }
+                }
+            });
+            app.UseOpenIddictServer();
+            app.UseOpenIddictValidation();
+
+            var configuration = new HttpConfiguration
+            {
+                DependencyResolver = new DefaultDependencyResolver(container)
+            };
+
+            configuration.MapHttpAttributeRoutes();
+
+            // Configure ASP.NET Web API to use token authentication.
+            configuration.Filters.Add(new HostAuthenticationFilter(OpenIddictValidationOwinDefaults.AuthenticationType));
+
+            // Register the Web API/Autofac integration middleware.
+            //app.UseAutofacWebApi(configuration);
+            app.UseWebApi(configuration);
+        }
+
+        private static ServiceProvider CreateContainer()
+        {
+            var services = new ServiceCollection();
+
+            services.AddOpenIddict()
+
+                // Register the OpenIddict server components.
+                .AddServer(options =>
+                {
+                    // Enable the token endpoint.
+                    options.SetTokenEndpointUris("/connect/token");
+
+                    // Enable the password and the refresh token flows.
+                    options.AllowPasswordFlow();
+
+                    // Enable the degraded to allow using the server feature without a backing database.
+                    options.EnableDegradedMode();
+
+                    // Accept anonymous clients (i.e clients that don't send a client_id).
+                    options.AcceptAnonymousClients();
+
+                    // Register the signing and encryption credentials.
+                    options.AddDevelopmentEncryptionCertificate()
+                           .AddDevelopmentSigningCertificate();
+
+                    // Register the OWIN host and configure the OWIN-specific options.
+                    options.UseOwin()
+                           .DisableTransportSecurityRequirement();
+
+                    options.RegisterScopes(Scopes.Email, Scopes.Profile, Scopes.Roles, "name");
+
+
+                    // Register an event handler responsible of validating token requests.
+                    options.AddEventHandler<ValidateTokenRequestContext>(builder =>
+                        builder.UseInlineHandler(context =>
+                        {
+                            // Client authentication is not used in this sample,
+                            // so there's nothing specific to validate here.
+
+                            return default;
+                        }));
+
+                    // Register an event handler responsible of handling token requests.
+                    options.AddEventHandler<HandleTokenRequestContext>(builder =>
+                        builder.UseInlineHandler(context =>
+                        {
+                            if (!context.Request.IsPasswordGrantType())
+                            {
+                                throw new InvalidOperationException("The specified grant type is not supported.");
+                            }
+
+                            // Validate the username/password parameters.
+                            //
+                            // In a real world application, you'd use likely use a key derivation function like PBKDF2 to slow
+                            // the client secret validation process down and a time-constant comparer to prevent timing attacks.
+                            if (!string.Equals(context.Request.Username, "alice@wonderland.com", StringComparison.Ordinal) ||
+                                !string.Equals(context.Request.Password, "P@ssw0rd", StringComparison.Ordinal))
+                            {
+                                context.Reject(
+                                    error: Errors.InvalidGrant,
+                                    description: "The username/password couple is invalid.");
+
+                                return default;
+                            }
+
+                            // Create a new identity containing the claims used to generate new tokens.
+                            var identity = new ClaimsIdentity(OpenIddictServerOwinDefaults.AuthenticationType);
+                            identity.AddClaim(new Claim(Claims.Subject, "999d4ea0-164f-4c1b-8585-b83f313995c9"));
+                            identity.AddClaim(new Claim(Claims.Name, "Alice").SetDestinations(Destinations.IdentityToken, Destinations.AccessToken));
+
+                            context.SignIn(new ClaimsPrincipal(identity));
+
+                            return default;
+                        }));
+                })
+
+                // Register the OpenIddict validation components.
+                .AddValidation(options =>
+                {
+                    // Import the configuration from the local OpenIddict server instance.
+                    options.UseLocalServer();
+
+                    // Register the OWIN host.
+                    options.UseOwin();
+                });
+            return services.BuildServiceProvider();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new sample project "KalarbaMSDI.Server" which is a port of Kalarba server without autofac dependency. Instead it uses Microsoft.Extensions.DependencyInjection

A little background why this PR: In our project we didn't use Autofac and found it difficult in the beginning to configure the Kalarba server without autofac. I managed to run it with just Microsoft dependency injection after all. Thought it would be helpful for someone like me to get started with Openiddict and Owin.