### PR TITLE
Refactor validation in authorization endpoint

### DIFF
--- a/samples/Balosar/Balosar.Server/Controllers/AuthorizationController.cs
+++ b/samples/Balosar/Balosar.Server/Controllers/AuthorizationController.cs
@@ -49,33 +49,6 @@ namespace Balosar.Server.Controllers
             var request = HttpContext.GetOpenIddictServerRequest() ??
                 throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
 
-            // Retrieve the user principal stored in the authentication cookie.
-            // If it can't be extracted, redirect the user to the login page.
-            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
-            if (result == null || !result.Succeeded)
-            {
-                // If the client application requested promptless authentication,
-                // return an error indicating that the user is not logged in.
-                if (request.HasPrompt(Prompts.None))
-                {
-                    return Forbid(
-                        authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
-                        properties: new AuthenticationProperties(new Dictionary<string, string>
-                        {
-                            [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.LoginRequired,
-                            [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "The user is not logged in."
-                        }));
-                }
-
-                return Challenge(
-                    authenticationSchemes: IdentityConstants.ApplicationScheme,
-                    properties: new AuthenticationProperties
-                    {
-                        RedirectUri = Request.PathBase + Request.Path + QueryString.Create(
-                            Request.HasFormContentType ? Request.Form.ToList() : Request.Query.ToList())
-                    });
-            }
-
             // If prompt=login was specified by the client application,
             // immediately return the user agent to the login page.
             if (request.HasPrompt(Prompts.Login))
@@ -98,11 +71,14 @@ namespace Balosar.Server.Controllers
                     });
             }
 
+            // Retrieve the user principal stored in the authentication cookie.
             // If a max_age parameter was provided, ensure that the cookie is not too old.
-            // If it's too old, automatically redirect the user agent to the login page.
-            if (request.MaxAge != null && result.Properties?.IssuedUtc != null &&
-                DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value))
+            // If the user principle can't be extracted or the cookie is too old, redirect the user to the login page.
+            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
+            if (result == null || !result.Succeeded || HasCookieExpired(request, result))
             {
+                // If the client application requested promptless authentication,
+                // return an error indicating that the user is not logged in.
                 if (request.HasPrompt(Prompts.None))
                 {
                     return Forbid(
@@ -358,6 +334,12 @@ namespace Balosar.Server.Controllers
             }
 
             throw new InvalidOperationException("The specified grant type is not supported.");
+        }
+
+        private bool HasCookieExpired(OpenIddictRequest request, AuthenticateResult result)
+        {
+            return request.MaxAge != null && result.Properties?.IssuedUtc != null &&
+                DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value);
         }
 
         private IEnumerable<string> GetDestinations(Claim claim, ClaimsPrincipal principal)

--- a/samples/Balosar/Balosar.Server/Controllers/AuthorizationController.cs
+++ b/samples/Balosar/Balosar.Server/Controllers/AuthorizationController.cs
@@ -73,7 +73,7 @@ namespace Balosar.Server.Controllers
 
             // Retrieve the user principal stored in the authentication cookie.
             // If a max_age parameter was provided, ensure that the cookie is not too old.
-            // If the user principle can't be extracted or the cookie is too old, redirect the user to the login page.
+            // If the user principal can't be extracted or the cookie is too old, redirect the user to the login page.
             var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
             if (result == null || !result.Succeeded || HasCookieExpired(request, result))
             {

--- a/samples/Velusia/Velusia.Server/Controllers/AuthorizationController.cs
+++ b/samples/Velusia/Velusia.Server/Controllers/AuthorizationController.cs
@@ -55,33 +55,6 @@ namespace Velusia.Server.Controllers
             var request = HttpContext.GetOpenIddictServerRequest() ??
                 throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
 
-            // Retrieve the user principal stored in the authentication cookie.
-            // If it can't be extracted, redirect the user to the login page.
-            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
-            if (result == null || !result.Succeeded)
-            {
-                // If the client application requested promptless authentication,
-                // return an error indicating that the user is not logged in.
-                if (request.HasPrompt(Prompts.None))
-                {
-                    return Forbid(
-                        authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
-                        properties: new AuthenticationProperties(new Dictionary<string, string>
-                        {
-                            [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.LoginRequired,
-                            [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = "The user is not logged in."
-                        }));
-                }
-
-                return Challenge(
-                    authenticationSchemes: IdentityConstants.ApplicationScheme,
-                    properties: new AuthenticationProperties
-                    {
-                        RedirectUri = Request.PathBase + Request.Path + QueryString.Create(
-                            Request.HasFormContentType ? Request.Form.ToList() : Request.Query.ToList())
-                    });
-            }
-
             // If prompt=login was specified by the client application,
             // immediately return the user agent to the login page.
             if (request.HasPrompt(Prompts.Login))
@@ -104,11 +77,14 @@ namespace Velusia.Server.Controllers
                     });
             }
 
+            // Retrieve the user principal stored in the authentication cookie.
             // If a max_age parameter was provided, ensure that the cookie is not too old.
-            // If it's too old, automatically redirect the user agent to the login page.
-            if (request.MaxAge != null && result.Properties?.IssuedUtc != null &&
-                DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value))
+            // If the user principle can't be extracted or the cookie is too old, redirect the user to the login page.
+            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
+            if (result == null || !result.Succeeded || HasCookieExpired(request, result))
             {
+                // If the client application requested promptless authentication,
+                // return an error indicating that the user is not logged in.
                 if (request.HasPrompt(Prompts.None))
                 {
                     return Forbid(
@@ -363,6 +339,12 @@ namespace Velusia.Server.Controllers
             }
 
             throw new InvalidOperationException("The specified grant type is not supported.");
+        }
+
+        private bool HasCookieExpired(OpenIddictRequest request, AuthenticateResult result)
+        {
+            return request.MaxAge != null && result.Properties?.IssuedUtc != null &&
+                DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value);
         }
 
         private IEnumerable<string> GetDestinations(Claim claim, ClaimsPrincipal principal)

--- a/samples/Velusia/Velusia.Server/Controllers/AuthorizationController.cs
+++ b/samples/Velusia/Velusia.Server/Controllers/AuthorizationController.cs
@@ -79,7 +79,7 @@ namespace Velusia.Server.Controllers
 
             // Retrieve the user principal stored in the authentication cookie.
             // If a max_age parameter was provided, ensure that the cookie is not too old.
-            // If the user principle can't be extracted or the cookie is too old, redirect the user to the login page.
+            // If the user principal can't be extracted or the cookie is too old, redirect the user to the login page.
             var result = await HttpContext.AuthenticateAsync(IdentityConstants.ApplicationScheme);
             if (result == null || !result.Succeeded || HasCookieExpired(request, result))
             {


### PR DESCRIPTION
The `AuthorizationEndpoint` handler perform the following steps at the beginning
- Get the authentication ticket
- validate authentication ticket
    - If not valid (error for `Prompts.None` otherwise, challenge "Login Page")
- Check for `Prompts.Login` to force challenge "Login Page"
- Validate cookie `max_age`
    - If not valid (error for `Prompts.None` otherwise, challenge "Login Page")
    
I think the `Prompts.Login` check should come first, while authentication and cookies validation should be combined in a single condition
- Require login prompt is an "OpenId Behavior"
- authentication ticket and cookie are "Authentication Validation"
> The suggested new order depends on ValidatePromptParameter performed by OpenIddict to make sure that `Prompts.None` does not used with other prompts like `Prompts.Login`