### PR TITLE
added link to the main readme to the readme of the samples folder

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -9,3 +9,6 @@ Each demo has its own RunDemo.ps1 script. E.g.
     .\ClientCredentialsFlow\RunDemo.ps1
     .\CodeFlow\RunDemo.ps1
     .\ImplicitFlow\RunDemo.ps1
+# Explanation
+
+You can find the explanation in the [README.md in the root of the repository](../README.md)


### PR DESCRIPTION
If you come from an external link to the samples folder, you might oversee that there is a root folder with a readme because there is the basic readme on how to use the samples. I added the link in there.