### PR TITLE
Allow newer sdk to build the project

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.101"
+    "version": "7.0.101",
+    "rollForward": "latestMinor"
   },
 
   "tools": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
     "version": "7.0.101",
-    "rollForward": "latestMinor"
+    "allowPrerelease": false,
+    "rollForward": "latestMajor"
   },
 
   "tools": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "7.0.101",
-    "allowPrerelease": false,
+    "allowPrerelease": true,
     "rollForward": "latestMajor"
   },
 

--- a/global.json
+++ b/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "7.0.101",
     "allowPrerelease": true,
-    "rollForward": "latestMajor"
+    "rollForward": "major"
   },
 
   "tools": {


### PR DESCRIPTION
I've just updated visual studio to 17.5. And I got only the 7.0.200 sdk which made it impossible to compile the solution after checking out. I am sure it was not meant to be fixed to this version of the runtime, certainly because lots of people will try this out. An easy workaround for this is to add the rollforward option, as described here:

https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward