### PR TITLE
Prepopulate email address of user logging in using external account on user registration page

### DIFF
--- a/samples/Velusia/Velusia.Server/Startup.cs
+++ b/samples/Velusia/Velusia.Server/Startup.cs
@@ -102,8 +102,16 @@ public class Startup
                        {
                            options.SetClientId("c4ade52327b01ddacff3")
                                   .SetClientSecret("da6bed851b75e317bf6b2cb67013679d9467c122")
-                                  .SetRedirectUri("callback/login/github");
-                       });
+                                  .SetRedirectUri("callback/login/github")
+                                  .AddScopes(Scopes.Email); // Will work only if github user has chosen to make their email public on their profile
+                    })
+                    .AddGoogle(googleConfig =>
+                    {
+                        googleConfig.SetClientId("Add Your Google Client ID here");
+                        googleConfig.SetClientSecret("Add your Google Client Secret here");
+                        googleConfig.SetRedirectUri("callback/login/google");
+                        googleConfig.AddScopes(Scopes.Email, Scopes.Profile, Scopes.OpenId);
+                    });
             })
 
             // Register the OpenIddict server components.


### PR DESCRIPTION
1. Added a section for google external login 2. Added a comment to add caveat for when requesting email scope from GitHub would not work