### PR TITLE
Update Startup.cs

### DIFF
--- a/samples/Velusia/Velusia.Server/Startup.cs
+++ b/samples/Velusia/Velusia.Server/Startup.cs
@@ -80,11 +80,6 @@ public class Startup
                 options.AddDevelopmentEncryptionCertificate()
                        .AddDevelopmentSigningCertificate();
 
-                // Register the ASP.NET Core host and configure the ASP.NET Core-specific options.
-                options.UseAspNetCore()
-                       .EnableStatusCodePagesIntegration()
-                       .EnableRedirectionEndpointPassthrough();
-
                 // Register the System.Net.Http integration and use the identity of the current
                 // assembly as a more specific user agent, which can be useful when dealing with
                 // providers that use the user agent as a way to throttle requests (e.g Reddit).


### PR DESCRIPTION
`OpenIddictClientBuilder` does not contain this method `UseAspNetCore()`.