### PR TITLE
Update the ASP.NET Web API samples to use SuppressDefaultHostAuthentication()

### DIFF
--- a/samples/Kalarba/Kalarba.Server/Startup.cs
+++ b/samples/Kalarba/Kalarba.Server/Startup.cs
@@ -128,6 +128,7 @@ public class Startup
         };
 
         configuration.MapHttpAttributeRoutes();
+        configuration.SuppressDefaultHostAuthentication();
 
         // Configure ASP.NET Web API to use token authentication.
         configuration.Filters.Add(new HostAuthenticationFilter(OpenIddictValidationOwinDefaults.AuthenticationType));

--- a/samples/Mortis/Mortis.Server/Startup.cs
+++ b/samples/Mortis/Mortis.Server/Startup.cs
@@ -103,6 +103,7 @@ namespace Mortis.Server
             };
 
             configuration.MapHttpAttributeRoutes();
+            configuration.SuppressDefaultHostAuthentication();
 
             // Register the Autofac Web API integration and Web API middleware.
             app.UseAutofacWebApi(configuration);


### PR DESCRIPTION
The ASP.NET 4.x sandbox in the [core repository uses `SuppressDefaultHostAuthentication()`](https://github.com/openiddict/openiddict-core/blob/e896a0f8d4646beef7ca2e05ff29933a13a76633/sandbox/OpenIddict.Sandbox.AspNet.Server/Startup.cs#L162-L167) to ensure the principal already attached to the request (e.g by the Katana cookie middleware) is always discarded but it's not used in the Web API samples found here. Since it's an unwanted behavior that confuses people and has security implications, this PR updates the 2 Web API samples to always call `SuppressDefaultHostAuthentication()`.