### PR TITLE
Remove "openid" from the list of scopes attached to the client registration used in the Zirku C# client

### DIFF
--- a/samples/Zirku/Zirku.Client1/Program.cs
+++ b/samples/Zirku/Zirku.Client1/Program.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Client;
 using Zirku.Client1;
-using static OpenIddict.Abstractions.OpenIddictConstants;
 
 var host = new HostBuilder()
     .ConfigureLogging(options => options.AddDebug())
@@ -58,7 +57,7 @@ var host = new HostBuilder()
 
                     ClientId = "console_app",
                     RedirectUri = new Uri("/", UriKind.Relative),
-                    Scopes = { Scopes.OpenId, "api1", "api2" }
+                    Scopes = { "api1", "api2" }
                 });
             });
 


### PR DESCRIPTION
The `openid` scope is automatically added by the OpenIddict client to the list of requested scopes when it detects the authorization server supports OpenID Connect so adding it explicitly is not necessary.