### PR TITLE
Changed Zirku.Client2 ports to match the ones in the server.

### DIFF
--- a/samples/Zirku/Zirku.Client2/Program.cs
+++ b/samples/Zirku/Zirku.Client2/Program.cs
@@ -1,4 +1,10 @@
 var builder = WebApplication.CreateBuilder(args);
+
 var app = builder.Build();
+
 app.UseStaticFiles();
+
+// Default redirect to the index page
+app.MapGet("/", () => Results.Redirect("/index.html"));
+
 app.Run();

--- a/samples/Zirku/Zirku.Client2/Program.cs
+++ b/samples/Zirku/Zirku.Client2/Program.cs
@@ -2,9 +2,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 var app = builder.Build();
 
+app.UseDefaultFiles();
 app.UseStaticFiles();
-
-// Default redirect to the index page
-app.MapGet("/", () => Results.Redirect("/index.html"));
 
 app.Run();

--- a/samples/Zirku/Zirku.Client2/Properties/launchSettings.json
+++ b/samples/Zirku/Zirku.Client2/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:12345/"
+      "applicationUrl": "http://localhost:5112/"
     }
   },
 
@@ -11,7 +11,7 @@
     "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:12345/",
+      "applicationUrl": "http://localhost:5112/",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
The port in `Zirku.Client2` project seems to be random in `launchSettings.json` and different from the one set in `Zirku.Server` for this application. Updated the port to match (12345 one did not work with the GitHub app, so I went with 5112 from the server app).

Also, added a default redirect to `index.html` in `Zirku.Client2` for convenience.