### PR TITLE
Excludes Jetbrains IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Jetbrains IDE folders
+.idea/*


### PR DESCRIPTION
This PR addresses [openiddict/samples/#2286](https://github.com/openiddict/openiddict-core/issues/2286) by excluding the `.idea` folder created by Rider and other JetBrains IDEs