### PR TITLE
Bump the .NET SDK to 10.0.302 and update all the dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,17 @@
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!--
+      Note: the EF Core SQLite package depends on a vulnerable version of SQLitePCLRaw.core.
+      Unfortunately, this package hasn't been updated to use the newer SourceGear.sqlite3 package,
+      which is not vulnerable. To work around that, this specific vulnerability is suppressed until
+      the EF Core team updates the package to use SourceGear.sqlite3 instead of SQLitePCLRaw.core.
+    -->
+
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform"         Version="4.1.0"   />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                   Version="8.0.1"   />
     <PackageVersion Include="Microsoft.Extensions.Hosting"                               Version="8.0.1"   />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                            Version="5.3.0"   />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                            Version="5.6.0"   />
     <PackageVersion Include="Microsoft.Owin.Diagnostics"                                 Version="4.2.3"   />
     <PackageVersion Include="Microsoft.Owin.Host.HttpListener"                           Version="4.2.3"   />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb"                              Version="4.2.3"   />
@@ -64,30 +64,30 @@
     <!--
       Note: the following references are exclusively used in the .NET 10.0 and ASP.NET Core 10.0 samples:
     -->
-    <PackageVersion Include="Aspire.Hosting.AppHost"                                     Version="13.3.4"   />
+    <PackageVersion Include="Aspire.Hosting.AppHost"                                     Version="13.4.6"   />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.AppServices"            Version="1.0.14"   />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.WinForms"               Version="1.0.14"   />
     <PackageVersion Include="Dapplo.Microsoft.Extensions.Hosting.Wpf"                    Version="1.0.14"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate"              Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly"                Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.8"   />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Negotiate"              Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly"                Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10"  />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Build"          Version="3.2.1"    />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer"      Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server"         Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf"                Version="10.0.60"  />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"       Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"          Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI"                           Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"          Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.Build"                                            Version="18.6.3"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                       Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools"                        Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                   Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.Extensions.Hosting"                               Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.Extensions.Http"                                  Version="10.0.8"   />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                       Version="10.6.0"   />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery"                      Version="10.6.0"   />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp"                 Version="10.6.0"   />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer"      Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server"         Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf"                Version="10.0.80"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"       Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"          Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI"                           Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"          Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.Build"                                            Version="18.7.1"   />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite"                       Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools"                        Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection"                   Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.Extensions.Hosting"                               Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.Extensions.Http"                                  Version="10.0.10"  />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience"                       Version="10.8.0"   />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery"                      Version="10.8.0"   />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp"                 Version="10.8.0"   />
     <PackageVersion Include="OpenIddict.Abstractions"                                    Version="7.5.0"    />
     <PackageVersion Include="OpenIddict.AspNetCore"                                      Version="7.5.0"    />
     <PackageVersion Include="OpenIddict.Client.SystemIntegration"                        Version="7.5.0"    />
@@ -97,14 +97,14 @@
     <PackageVersion Include="OpenIddict.Quartz"                                          Version="7.5.0"    />
     <PackageVersion Include="OpenIddict.Validation.AspNetCore"                           Version="7.5.0"    />
     <PackageVersion Include="OpenIddict.Validation.SystemNetHttp"                        Version="7.5.0"    />
-    <PackageVersion Include="Quartz.Extensions.Hosting"                                  Version="3.18.1"   />
-    <PackageVersion Include="Spectre.Console"                                            Version="0.55.2"   />
+    <PackageVersion Include="Quartz.Extensions.Hosting"                                  Version="3.18.2"   />
+    <PackageVersion Include="Spectre.Console"                                            Version="0.57.2"   />
     <PackageVersion Include="Yarp.ReverseProxy"                                          Version="2.3.0"    />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"               Version="1.15.3"   />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting"                           Version="1.15.3"   />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore"                   Version="1.15.2"   />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http"                         Version="1.15.1"   />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime"                      Version="1.15.1"   />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"               Version="1.16.0"   />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting"                           Version="1.16.0"   />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore"                   Version="1.16.0"   />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http"                         Version="1.16.0"   />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime"                      Version="1.16.0"   />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "sdk": {
-    "version": "10.0.300",
+    "version": "10.0.302",
     "allowPrerelease": true,
     "rollForward": "major"
   },
 
   "tools": {
-    "dotnet": "10.0.300"
+    "dotnet": "10.0.302"
   },
 
   "msbuild-sdks": {


### PR DESCRIPTION
Note: the `GHSA-2m69-gcr7-jv3q` has to be suppressed for the time being.